### PR TITLE
Fix audio file playback update

### DIFF
--- a/Vect_1.py
+++ b/Vect_1.py
@@ -119,6 +119,7 @@ class AudioOutput:
     def generate_continuous_buffer(self):
         if self.is_file_mode:
             return
+        self.file_playing = False
         self.last_params = (self.left_wave, self.left_freq, self.left_amp, self.right_wave, self.right_freq, self.right_amp)
         duration = 10.0
         l = generate_wave(self.left_wave, self.left_freq, self.left_amp, duration=duration)
@@ -133,6 +134,7 @@ class AudioOutput:
 
     def play_audio_file(self, file_path):
         self.is_file_mode = True
+        self.file_playing = True
         if self.channel:
             self.channel.stop()
 


### PR DESCRIPTION
## Summary
- ensure `AudioOutput.update_file_playback` runs by setting `file_playing` flag
- reset `file_playing` when switching back to tone generator mode

## Testing
- `python -m py_compile Vect_1.py`

------
https://chatgpt.com/codex/tasks/task_e_688ace0a84d88325b6ce176d2ec6e90a